### PR TITLE
feat: skip listener when no window

### DIFF
--- a/src/useScrollPosition.jsx
+++ b/src/useScrollPosition.jsx
@@ -27,6 +27,10 @@ export function useScrollPosition(effect, deps, element, useWindow, wait) {
   }
 
   useLayoutEffect(() => {
+    if (!isBrowser) {
+      return
+    }
+
     const handleScroll = () => {
       if (wait) {
         if (throttleTimeout === null) {


### PR DESCRIPTION
Add condition to not `window.addEventlistener` when there is no window.