### PR TITLE
Define explicit return type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,4 +7,4 @@ export declare function useScrollPosition(
   element?: MutableRefObject<HTMLElement | null>,
   useWindow?: boolean,
   wait?: number
-);
+): void;


### PR DESCRIPTION
The typings for `useScrollPosition` are incomplete, as they do not define an explicit return type. This can lead TypeScript to throw a build error with the following message:

```
(4,25): 'useScrollPosition', which lacks return-type annotation, implicitly has an 'any' return type.
```

The function should indicate that it returns `void`, as it does not have an actual return.