### PR TITLE
Better typings for effect props

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,8 +1,18 @@
 import {DependencyList, EffectCallback, MutableRefObject} from "react";
 
+interface ScrollProps {
+  prevPos: {
+    x: Number;
+    y: Number;
+  },
+  currPos: {
+    x: Number;
+    y: Number;
+  }
+}
 
 export declare function useScrollPosition(
-  effect: EffectCallback | Object,
+  effect: (arg0: ScrollProps) => void,
   deps?: DependencyList,
   element?: MutableRefObject<HTMLElement | null>,
   useWindow?: boolean,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -12,7 +12,7 @@ interface ScrollProps {
 }
 
 export declare function useScrollPosition(
-  effect: (arg0: ScrollProps) => void,
+  effect: (props: ScrollProps) => void,
   deps?: DependencyList,
   element?: MutableRefObject<HTMLElement | null>,
   useWindow?: boolean,


### PR DESCRIPTION
I'm not sure why the effect is a type of `EffectCallback | Object`. So I propose to change it.