### PR TITLE
SSR warning useLayoutEfect

### DIFF
--- a/src/useIsomorphicLayoutEffect.jsx
+++ b/src/useIsomorphicLayoutEffect.jsx
@@ -1,0 +1,3 @@
+import { useLayoutEffect, useEffect } from 'react'
+
+export const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect

--- a/src/useScrollPosition.jsx
+++ b/src/useScrollPosition.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useRef, useLayoutEffect } from 'react'
+import { useRef } from 'react'
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 
 const isBrowser = typeof window !== `undefined`
 
@@ -26,7 +27,7 @@ export function useScrollPosition(effect, deps, element, useWindow, wait) {
     throttleTimeout = null
   }
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!isBrowser) {
       return
     }


### PR DESCRIPTION
There's a warning when you're working with Server Side Render due to useLayoutEffect.

```
Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client.
```

