### PR TITLE
fix: change Number types to number

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,13 +1,13 @@
-import {DependencyList, EffectCallback, MutableRefObject} from "react";
+import { DependencyList, EffectCallback, MutableRefObject } from "react";
 
 interface ScrollProps {
   prevPos: {
-    x: Number;
-    y: Number;
+    x: number;
+    y: number;
   },
   currPos: {
-    x: Number;
-    y: Number;
+    x: number;
+    y: number;
   }
 }
 


### PR DESCRIPTION
Changes the types of the x and y coordinates to use `number` instead of `Number`. This allows to use the coordinatines in artihmetic operations. See the [TypeScript handbook](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#number-string-boolean-symbol-and-object) for more information.

Fixes #10 