### PR TITLE
Fix for IE9-IE11, window.scrollY is NaN

### DIFF
--- a/src/useScrollPosition.jsx
+++ b/src/useScrollPosition.jsx
@@ -11,7 +11,7 @@ function getScrollPosition({ element, useWindow }) {
   const position = target.getBoundingClientRect()
 
   return useWindow
-    ? { x: window.scrollX, y: window.scrollY }
+    ? { x: window.pageXOffset, y: window.pageYOffset }
     : { x: position.left, y: position.top }
 }
 


### PR DESCRIPTION
This fix is for the IE9-IE11, due to lack of support for the method `window.scrollX` and `window.scrollY`.

I have replaced them with `window.pageXOffset`, `window.pageYOffset` as it has a wider support.