### PR TITLE
clearTimeout

### DIFF
--- a/src/useScrollPosition.jsx
+++ b/src/useScrollPosition.jsx
@@ -44,7 +44,10 @@ export function useScrollPosition(effect, deps, element, useWindow, wait) {
 
     window.addEventListener('scroll', handleScroll)
 
-    return () => window.removeEventListener('scroll', handleScroll)
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      throttleTimeout && clearTimeout(throttleTimeout);
+    }
   }, deps)
 }
 


### PR DESCRIPTION
Must clear the throttleTimeout if it is set.  This will prevent a memory leak and undesired side effects if the component is unmounted before the timeout has completed.