### PR TITLE
Adding a check for undefined target

### DIFF
--- a/src/useScrollPosition.jsx
+++ b/src/useScrollPosition.jsx
@@ -3,11 +3,15 @@ import { useRef } from 'react'
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 
 const isBrowser = typeof window !== `undefined`
+const zeroPosition = { x: 0, y: 0 };
 
-function getScrollPosition({ element, useWindow }) {
-  if (!isBrowser) return { x: 0, y: 0 }
+function getScrollPosition({ element, useWindow }) {  
+  if (!isBrowser) return zeroPosition
 
   const target = element ? element.current : document.body
+
+  if(!target) return zeroPosition
+
   const position = target.getBoundingClientRect()
 
   return useWindow


### PR DESCRIPTION
Just adding a little check to prevent calling `getBoundingClientRect` of undefined.
Got a few of those on my bug tracking these days.