### PR TITLE
Fixes #41

### DIFF
--- a/src/useScrollPosition.tsx
+++ b/src/useScrollPosition.tsx
@@ -11,7 +11,7 @@ interface IScrollProps {
   currPos: IPosition;
 }
 
-type ElementRef = MutableRefObject<HTMLElement | undefined>;
+type ElementRef = MutableRefObject<HTMLElement | null>;
 
 const isBrowser = typeof window !== `undefined`;
 const zeroPosition = { x: 0, y: 0 };


### PR DESCRIPTION
Fixes #41 

```
Argument of type 'MutableRefObject<HTMLElement | null>' is not assignable to parameter of type 'MutableRefObject<HTMLElement | undefined>'.
Type 'HTMLElement | null' is not assignable to type 'HTMLElement | undefined'.
Type 'null' is not assignable to type 'HTMLElement | undefined'.ts(2345)
```